### PR TITLE
Add module and project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,225 +1,55 @@
-# Spendify - AI-Powered Receipt Processing System
+# Spendify
 
-## Overview
+AI-driven system for processing receipt images, classifying line items and tracking personal spending.
 
-Spendify is a comprehensive receipt processing and classification system that combines Discord bot integration, Google Cloud AI services, and multi-agent AI pipelines to automatically categorize and analyze receipt data.
+---
 
-## Architecture
-
-```
-Discord Bot → Main API → GCP Document AI → Receipt Classifier Agents → Firebase Storage
-```
-
-## Key Features
-
-- **Discord Integration**: Upload receipts directly through Discord
-- **OCR Processing**: Extract text and entities using Google Cloud Document AI
-- **AI Classification**: Multi-agent pipeline for intelligent item categorization
-- **Data Validation**: Automatic validation with receipt total reconciliation
-- **Cloud Storage**: Structured data storage in Firebase Firestore
-- **Multi-format Support**: Handles various receipt formats and layouts
-
-## System Components
-
-### 1. Entry Points
-
-#### Discord Bot (`bot.py`)
-- Accepts image uploads from Discord users
-- Handles user registration and authentication
-- Manages file uploads and session tracking
-- Provides real-time feedback to users
-
-#### Main API (`main_api.py`)
-- Central Flask API server
-- Orchestrates the entire processing pipeline
-- Handles user management and data flow
-- Integrates all system components
-
-### 2. Data Processing
-
-#### GCP Document AI (`gcp_docai.py`)
-- Extracts structured data from receipt images
-- Identifies line items, totals, taxes, and merchant information
-- Provides entity recognition and text extraction
-
-#### Firebase Storage (`firebase_store.py`)
-- Manages all data persistence operations
-- Stores user data, sessions, raw OCR data, and classifications
-- Provides structured data organization across collections
-
-### 3. AI Classification Pipeline
-
-#### ADK Client (`gcp_adk_classification.py`)
-- HTTP client for Google Agent Development Kit
-- Handles communication with multi-agent systems
-- Manages session creation and event streaming
-
-#### Receipt Classifier Agents (`receipt_classifier/`)
-Multi-agent system with sequential processing:
-
-1. **Initial Classifier**: Categorizes line items (Groceries, Fast Food, etc.)
-2. **Grouping Agent**: Groups items by category with totals
-3. **Validation Loop**: 
-   - **Reviewer**: Validates classification accuracy
-   - **Refiner**: Corrects misclassifications
-4. **Response Agent**: Generates final summary and saves to Firebase
-
-## Data Flow
-
-1. User uploads receipt image via Discord
-2. Bot saves image locally and calls API
-3. API processes image through GCP Document AI
-4. OCR extracts entities (items, totals, taxes)
-5. Raw data stored in Firebase
-6. Classification pipeline triggered via ADK
-7. Multi-agent system processes receipt:
-   - Classifies items by category
-   - Groups and calculates totals
-   - Validates against receipt total
-   - Refines if validation fails
-8. Final classified data saved to Firebase
-
-## Usage
-
-### Starting the System
-
-1. **Start the Main API**:
-```bash
-python main_api.py
-```
-
-2. **Start the Discord Bot**:
-```bash
-python bot.py
-```
-
-3. **Start the ADK Server**
-```bash
-adk web
-```
-
-4. **Upload Receipts**:
-   - Send image attachments to the Discord bot
-   - Bot will process and classify automatically
-   - Results stored in Firebase collections
-
-### API Endpoints
-#### main_api.py
-- `POST /register` - Register new user
-- `GET /get_primary` - Get user's primary ID
-- `POST /upload` - Process receipt image
-#### adk web
-- refer to /docs on the web.
-
-
-### Discord Commands
-
-- Upload any image attachment to trigger processing
-- Bot handles registration flow automatically
-- Provides session tracking and status updates
-
-## Data Storage Structure
-
-### Firebase Collections
+## 🏗️ Architecture
 
 ```
-USERDATA/
-├── {primary_id}/
-│   ├── sources/
-│   │   └── {source}: {identifier}
-│   └── metadata
-
-SESSIONS/
-├── {session_id}/
-│   ├── timestamp
-│   ├── user_id
-│   └── source
-
-DATA/
-├── RAW_DATA/
-│   └── {date}/
-│       └── {session_id}: raw_ocr_data
-├── RECEIPTS/
-│   └── {date}/
-│       └── {session_id}: extracted_entities
-└── SUMMARIES/
-    └── {date}/
-        └── {session_id}: classified_data
+Discord Bot → Flask API → Google Document AI → ADK Classification Pipeline → Firebase
 ```
 
-## Agent Pipeline Details
+1. **Discord Bot** – receives receipt images from users and forwards them to the API.
+2. **Flask API** – orchestrates OCR, classification and data storage, also serving a simple dashboard.
+3. **ADK Pipeline** – multi-agent system that groups and validates receipt items.
+4. **Firebase** – persists raw OCR data and summarised spending information.
 
-### Validation Process
-1. Calculate total from classified items
-2. Compare with receipt total
-3. If mismatch > threshold, trigger refinement
-4. Refiner adjusts classifications to match total
-5. Final validation before saving
+![Process Flow](process.png)
 
-## Error Handling
+---
 
-- Automatic fallback for OCR failures
-- Retry logic for API calls
-- Graceful degradation for classification errors
-- Comprehensive logging throughout pipeline
+## 📁 Repository Structure
 
-## Development
+| Folder        | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `discord_bot` | Bot for collecting images from Discord users.    |
+| `flask_api`   | Flask service performing OCR and classification. |
+| `adk_pipeline`| Agent Development Kit pipeline for receipts.     |
 
-### Project Structure
-```
-Spendify/
-├── discord_bot/               # Discord bot module
-│   ├── bot.py                # Main Discord bot
-│   ├── requirements.txt      # Bot dependencies
-│   ├── deploy-bot.md         # Bot deployment guide
-│   └── .env.template         # Environment template
-├── flask_api/                # Main API server module
-│   ├── main_api.py           # Flask API server
-│   ├── gcp_docai.py          # OCR processing
-│   ├── firebase_store.py     # Data storage
-│   ├── gcp_adk_classification.py # ADK client
-│   ├── requirements.txt      # API dependencies
-│   ├── deploy-api.md         # API deployment guide
-│   ├── Dockerfile.api        # Docker configuration
-│   ├── uploads/              # API file uploads
-│   └── .env.template         # Environment template
-├── adk_pipeline/             # Agent Development Kit pipeline
-│   ├── receipt_classifier/   # Agent pipeline
-│   │   ├── agent.py          # Root agent
-│   │   ├── subagents/        # Individual agents
-│   │   └── __init__.py       # Package initialization
-│   ├── requirements.txt      # ADK dependencies
-│   ├── deploy-adk.md         # ADK deployment guide
-│   ├── flow.png              # Pipeline flow diagram
-│   └── README.md             # ADK documentation
-├── dashboard/                # UI dashboard module
-│   ├── requirements.txt      # Dashboard dependencies
-│   ├── deploy-ui.md          # Dashboard deployment guide
-│   └── .env.template         # Environment template
-├── process.png               # System process diagram
-└── README.md                 # Project documentation
-```
+---
 
-### Adding New Features
+## 🚀 Quick Start
 
-1. **New Classification Categories**: Update agent schemas and prompts
-2. **Additional Data Sources**: Extend bot.py with new integrations
-3. **Enhanced Validation**: Modify reviewer/refiner agents
-4. **Custom Storage**: Update firebase_store.py collections
+1. Install Python requirements in each module.
+2. Configure `.env` files using the provided templates.
+3. Start the Flask API:
+   ```bash
+   cd flask_api
+   python main_api.py
+   ```
+4. In another terminal, run the Discord bot:
+   ```bash
+   cd discord_bot
+   python bot.py
+   ```
+5. Access the dashboard at `http://localhost:8080/` (or your configured port).
 
-## Monitoring and Logging
+---
 
-- Comprehensive logging across all components
-- Session tracking for debugging
-- Error capture and reporting
-- Performance metrics collection
+## 🔧 Extending Spendify
 
-## Contributing
+* Modify the ADK agents under `adk_pipeline/receipt_classifier` to tweak classification behaviour.
+* Adjust `firebase_store.py` if you prefer another database backend.
+* Adapt `discord_bot/bot.py` for different chat platforms.
 
-1. Fork the repository
-2. Create feature branch
-3. Add tests for new functionality
-4. Update documentation
-5. Submit pull request
-
-![SPENDIFY Process Flow](process.png)

--- a/discord_bot/README.md
+++ b/discord_bot/README.md
@@ -1,0 +1,53 @@
+# Discord Bot
+
+An interactive bot for uploading receipt images directly from Discord to the Spendify processing pipeline.
+
+---
+
+## 🤖 Bot Overview
+
+This bot listens for image attachments in any channel it has access to. When a user sends a receipt image, the bot:
+
+1. Ensures the user is registered via the API.
+2. Saves the image locally with a session ID.
+3. Uploads the image to the Flask API for processing.
+4. Provides status feedback in Discord.
+
+---
+
+## 💡 Key Features
+
+* **Interactive registration** – the bot guides new users through creating a primary ID.
+* **Asynchronous uploads** – images are uploaded in the background while the user continues chatting.
+* **Session tracking** – each upload is associated with a unique session ID for later reference.
+
+---
+
+## 🚀 Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.template` to `.env` and fill in:
+   - `DISCORD_TOKEN` – your Discord bot token.
+   - `API_URL` – base URL of the Flask API.
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```
+
+---
+
+## 📝 Commands
+
+The bot does not use complex commands. Simply upload an image in a channel where the bot is present. If the user is unregistered, the bot will prompt for registration through chat messages.
+
+---
+
+## 🛠️ Extending the Bot
+
+* **Additional platforms** – adapt `process_upload` to send images to other APIs.
+* **Custom prefixes or commands** – modify the `commands.Bot` initialization in `bot.py`.
+* **Persistent storage** – change where images are temporarily saved before upload.
+

--- a/flask_api/README.md
+++ b/flask_api/README.md
@@ -1,0 +1,63 @@
+# Flask API
+
+Central service that receives uploaded receipts, extracts data with Google Document AI, classifies items via the ADK pipeline and stores results in Firebase.
+
+---
+
+## 🌐 API Overview
+
+The API exposes endpoints for user registration, file uploads and data retrieval. On upload it performs:
+
+1. OCR extraction using Document AI.
+2. Grouping of recognised entities.
+3. Optional classification via the ADK pipeline.
+4. Persistence of raw and summarised data in Firebase.
+
+---
+
+## 💡 Key Features
+
+* **Document AI integration** for robust OCR across many receipt formats.
+* **Firebase storage** of sessions, raw OCR data and classification results.
+* **Dashboard endpoint** (`/`) serving a simple spending summary UI.
+
+---
+
+## 🚀 Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.template` to `.env` and configure:
+   - `API_PORT` – port to run the Flask server.
+   - `CLASSIFICATION_URL` – URL of the ADK classification service.
+   - `FIREBASE_CREDENTIALS` – path to your Firebase service account JSON.
+   - `GOOGLE_APPLICATION_PATH` and `DOCUMENT_AI_PROCESSOR_URL` for Document AI.
+3. Run the API locally:
+   ```bash
+   python main_api.py
+   ```
+   The dashboard will be available at `http://localhost:<API_PORT>/`.
+
+---
+
+## 📝 Endpoints
+
+| Method | Path          | Description                       |
+| ------ | ------------- | --------------------------------- |
+| `POST` | `/register`   | Register a new user source.       |
+| `GET`  | `/get_primary`| Look up a user's primary ID.      |
+| `POST` | `/upload`     | Upload a receipt image.           |
+| `GET`  | `/summary`    | Aggregated spend summary.         |
+| `GET`  | `/get_data`   | Raw summarised data for analysis. |
+| `GET`  | `/health`     | Health check for monitoring.      |
+
+---
+
+## 🛠️ Extending the API
+
+* **Additional processing** – customise `main_api.py` to add new validation or analytics.
+* **Alternate storage backends** – replace `firebase_store.py` with your database of choice.
+* **Custom dashboards** – modify files under `dashboard/` for a tailored UI.
+


### PR DESCRIPTION
## Summary
- replace project README with concise overview and quickstart
- document the Discord bot usage and setup
- add README for the Flask API service

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c733a2b8483258c4ec0133ce1cad8