### PR TITLE
Improve dashboard Google login

### DIFF
--- a/flask_api/dashboard/index.html
+++ b/flask_api/dashboard/index.html
@@ -40,7 +40,6 @@
     #loginBox {
       background:#fff; padding:30px; border-radius:12px; box-shadow:0 6px 10px rgba(0,0,0,0.15); width:340px; text-align:center;
     }
-    #loginBox input { width:100%; padding:10px; margin-bottom:15px; border:1px solid #ccc; border-radius:6px; }
     #loginBox button { width:100%; background:#6246ea; color:#fff; border:none; padding:12px; border-radius:8px; cursor:pointer; }
   </style>
 </head>
@@ -48,9 +47,7 @@
   <div id="loginContainer">
     <div id="loginBox">
       <h2>Login</h2>
-      <input type="text" id="primaryInput" placeholder="Enter Primary ID" />
-      <button id="loginBtn">Continue</button>
-      <p><a href="/register_user">New user? Register here</a></p>
+      <button id="googleLoginBtn">Sign in with Google</button>
     </div>
   </div>
 
@@ -117,8 +114,7 @@
 
     const loginContainer = document.getElementById('loginContainer');
     const dashboard = document.getElementById('dashboard');
-    const loginBtn = document.getElementById('loginBtn');
-    const primaryInput = document.getElementById('primaryInput');
+    const googleBtn = document.getElementById('googleLoginBtn');
     const usernameEl = document.getElementById('username');
     const logoutBtn = document.getElementById('logoutBtn');
 
@@ -149,23 +145,24 @@
       return true;
     }
 
-    async function ensureAuthenticated(primary, sessionId) {
+    async function handleGoogleLogin() {
       const provider = new GoogleAuthProvider();
       const result = await signInWithPopup(auth, provider);
       const idToken = await result.user.getIdToken();
-      await fetch(`/authenticate/FALSE/${sessionId}`, {
-        method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({idToken})
+      const resp = await fetch('/login_check', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ idToken })
       });
-    }
-
-    async function handleLogin() {
-      const primary = primaryInput.value.trim();
-      if (!primary) return;
-      const resp = await fetch('/register', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({source:'WEB', identifier: primary, primary_id: primary})});
       const data = await resp.json();
-      await ensureAuthenticated(primary, data.session_id);
-      localStorage.setItem('primary_id', primary);
-      await showDashboard(primary);
+      if (data.status === 'existing') {
+        localStorage.setItem('primary_id', data.primary_id);
+        await showDashboard(data.primary_id);
+      } else if (data.status === 'new') {
+        window.location.href = '/register_user';
+      } else {
+        alert('Login failed');
+      }
     }
 
     async function showDashboard(primary) {
@@ -175,7 +172,7 @@
       await fetchSummary(primary);
     }
 
-    loginBtn.onclick = handleLogin;
+    googleBtn.onclick = handleGoogleLogin;
     logoutBtn.onclick = async () => {
       await signOut(auth);
       localStorage.removeItem('primary_id');

--- a/flask_api/main_api.py
+++ b/flask_api/main_api.py
@@ -6,7 +6,7 @@ from gcp_docai import extract_receipt_data
 from firebase_store import (
     get_primary_id, create_user,
     save_session_meta, save_raw_data, save_receipt_data, save_summarised_data,
-    authenticate, get_all_summarised_data_as_df, get_user_document
+    authenticate, login_check, get_all_summarised_data_as_df, get_user_document
 )
 from io import BytesIO
 from PIL import Image
@@ -43,6 +43,7 @@ def serve_dashboard():
 
 app.route('/authenticate/<main_source>/<session_id>', methods=['POST'])(authenticate)
 app.route('/authenticate/<main_source>/<session_id>/', methods=['POST'])(authenticate)
+app.route('/login_check', methods=['POST'])(login_check)
 
 @app.route('/login', defaults={'main_source': 'FALSE', 'session_id': None}, methods=['GET'])
 @app.route('/login/', defaults={'main_source': 'FALSE', 'session_id': None}, methods=['GET'])


### PR DESCRIPTION
## Summary
- add `/login_check` endpoint for handling Google login
- adjust dashboard to sign in with Google first
- update login flow with `login_check`

## Testing
- `python -m py_compile flask_api/firebase_store.py flask_api/main_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb72ea764832596a7a16a49bcbd95