### PR TITLE
Add upload and chat pages to dashboard

### DIFF
--- a/flask_api/dashboard/chat.html
+++ b/flask_api/dashboard/chat.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chat with Bot - Spendify</title>
+  <style>
+    body { font-family: 'Segoe UI', sans-serif; margin: 0; background: #f9f9fc; }
+    .sidebar {
+      width: 220px; background: #fff; height: 100vh; position: fixed;
+      border-right: 1px solid #e0e0e0; padding: 1rem;
+    }
+    .sidebar h2 { color: #6246ea; margin-bottom: 2rem; }
+    .sidebar nav a {
+      display: block; padding: 10px; text-decoration: none; color: #333;
+      border-radius: 5px; margin-bottom: 0.5rem;
+    }
+    .sidebar nav a:hover { background: #f0f0f0; }
+    .main { margin-left: 240px; padding: 2rem; }
+    .header { margin-bottom: 2rem; display:flex; justify-content:space-between; align-items:center; }
+    #chatBox { height:400px; overflow-y:auto; border:1px solid #e0e0e0; padding:1rem; background:#fff; margin-bottom:1rem; }
+    #loginContainer { display:none; height:100vh; display:flex; justify-content:center; align-items:center; }
+    #loginBox {
+      background:#fff; padding:30px; border-radius:12px; box-shadow:0 6px 10px rgba(0,0,0,0.15); width:340px; text-align:center;
+    }
+    #loginBox button { width:100%; background:#6246ea; color:#fff; border:none; padding:12px; border-radius:8px; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div id="loginContainer">
+    <div id="loginBox">
+      <h2>Login</h2>
+      <button id="googleLoginBtn">Sign in with Google</button>
+    </div>
+  </div>
+
+  <div id="dashboard" style="display:none;">
+    <div class="sidebar">
+      <h2>Spendify</h2>
+      <nav>
+        <a href="/">🏠 Dashboard</a>
+        <a href="/upload_page">📤 Upload Receipt</a>
+        <a href="/chat_page">💬 Chat with Bot</a>
+      </nav>
+    </div>
+
+    <div class="main">
+      <div class="header">
+        <div>
+          <h1>Chat with Bot</h1>
+          <p>Ask any questions about your spending</p>
+        </div>
+        <button id="logoutBtn" style="background:#e53e3e;color:#fff;border:none;padding:8px 16px;border-radius:6px;cursor:pointer;">Logout</button>
+      </div>
+      <div id="chatBox"></div>
+      <input type="text" id="chatInput" placeholder="Type a message..." style="width:80%;"/>
+      <button id="sendBtn">Send</button>
+    </div>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js';
+    import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+
+    const firebaseConfig = {{ firebase_config | tojson }};
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+
+    const loginContainer = document.getElementById('loginContainer');
+    const dashboard = document.getElementById('dashboard');
+    const googleBtn = document.getElementById('googleLoginBtn');
+    const logoutBtn = document.getElementById('logoutBtn');
+    const chatBox = document.getElementById('chatBox');
+    const chatInput = document.getElementById('chatInput');
+    const sendBtn = document.getElementById('sendBtn');
+
+    async function handleGoogleLogin() {
+      const provider = new GoogleAuthProvider();
+      const result = await signInWithPopup(auth, provider);
+      const idToken = await result.user.getIdToken();
+      const resp = await fetch('/login_check', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ idToken })
+      });
+      const data = await resp.json();
+      if (data.status === 'existing') {
+        localStorage.setItem('primary_id', data.primary_id);
+        showDashboard();
+      } else if (data.status === 'new') {
+        window.location.href = '/register_user';
+      } else {
+        alert('Login failed');
+      }
+    }
+
+    function showDashboard() {
+      loginContainer.style.display = 'none';
+      dashboard.style.display = 'block';
+    }
+
+    googleBtn.onclick = handleGoogleLogin;
+    logoutBtn.onclick = async () => {
+      await signOut(auth);
+      localStorage.removeItem('primary_id');
+      location.reload();
+    };
+
+    window.addEventListener('load', async () => {
+      const stored = localStorage.getItem('primary_id');
+      if (stored) {
+        const res = await fetch(`/get_user?primary_id=${stored}`);
+        if (res.ok) {
+          const doc = await res.json();
+          if (doc.auth) { showDashboard(); return; }
+        }
+      }
+      loginContainer.style.display = 'flex';
+    });
+
+    async function sendMessage() {
+      const text = chatInput.value.trim();
+      if (!text) return;
+      chatBox.innerHTML += `<div><strong>You:</strong> ${text}</div>`;
+      chatInput.value = '';
+      const resp = await fetch('/chat', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({ message: text })
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        chatBox.innerHTML += `<div><strong>Bot:</strong> ${data.response}</div>`;
+      } else {
+        chatBox.innerHTML += '<div><em>Error communicating with server</em></div>';
+      }
+      chatBox.scrollTop = chatBox.scrollHeight;
+    }
+
+    sendBtn.onclick = sendMessage;
+    chatInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') sendMessage(); });
+  </script>
+</body>
+</html>

--- a/flask_api/dashboard/index.html
+++ b/flask_api/dashboard/index.html
@@ -106,7 +106,9 @@
     <div class="sidebar">
       <h2>Spendify</h2>
       <nav>
-        <a href="#">🏠 Dashboard</a>
+        <a href="/">🏠 Dashboard</a>
+        <a href="/upload_page">📤 Upload Receipt</a>
+        <a href="/chat_page">💬 Chat with Bot</a>
       </nav>
     </div>
 

--- a/flask_api/dashboard/upload.html
+++ b/flask_api/dashboard/upload.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Upload Receipt - Spendify</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { font-family: 'Segoe UI', sans-serif; margin: 0; background: #f9f9fc; }
+    .sidebar {
+      width: 220px; background: #fff; height: 100vh; position: fixed;
+      border-right: 1px solid #e0e0e0; padding: 1rem;
+    }
+    .sidebar h2 { color: #6246ea; margin-bottom: 2rem; }
+    .sidebar nav a {
+      display: block; padding: 10px; text-decoration: none; color: #333;
+      border-radius: 5px; margin-bottom: 0.5rem;
+    }
+    .sidebar nav a:hover { background: #f0f0f0; }
+    .main { margin-left: 240px; padding: 2rem; }
+    .header { margin-bottom: 2rem; display:flex; justify-content:space-between; align-items:center; }
+    #loginContainer { display:none; height:100vh; display:flex; justify-content:center; align-items:center; }
+    #loginBox {
+      background:#fff; padding:30px; border-radius:12px; box-shadow:0 6px 10px rgba(0,0,0,0.15); width:340px; text-align:center;
+    }
+    #loginBox button { width:100%; background:#6246ea; color:#fff; border:none; padding:12px; border-radius:8px; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <div id="loginContainer">
+    <div id="loginBox">
+      <h2>Login</h2>
+      <button id="googleLoginBtn">Sign in with Google</button>
+    </div>
+  </div>
+
+  <div id="dashboard" style="display:none;">
+    <div class="sidebar">
+      <h2>Spendify</h2>
+      <nav>
+        <a href="/">🏠 Dashboard</a>
+        <a href="/upload_page">📤 Upload Receipt</a>
+        <a href="/chat_page">💬 Chat with Bot</a>
+      </nav>
+    </div>
+
+    <div class="main">
+      <div class="header">
+        <div>
+          <h1>Upload Receipt</h1>
+          <p>Select an image to process</p>
+        </div>
+        <button id="logoutBtn" style="background:#e53e3e;color:#fff;border:none;padding:8px 16px;border-radius:6px;cursor:pointer;">Logout</button>
+      </div>
+      <input type="file" id="receiptFile" accept="image/*" />
+      <button id="uploadBtn" style="margin-left:1rem;">Upload</button>
+      <p id="uploadResult"></p>
+    </div>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-app.js';
+    import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from 'https://www.gstatic.com/firebasejs/12.0.0/firebase-auth.js';
+
+    const firebaseConfig = {{ firebase_config | tojson }};
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+
+    const loginContainer = document.getElementById('loginContainer');
+    const dashboard = document.getElementById('dashboard');
+    const googleBtn = document.getElementById('googleLoginBtn');
+    const logoutBtn = document.getElementById('logoutBtn');
+
+    async function handleGoogleLogin() {
+      const provider = new GoogleAuthProvider();
+      const result = await signInWithPopup(auth, provider);
+      const idToken = await result.user.getIdToken();
+      const resp = await fetch('/login_check', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ idToken })
+      });
+      const data = await resp.json();
+      if (data.status === 'existing') {
+        localStorage.setItem('primary_id', data.primary_id);
+        showDashboard();
+      } else if (data.status === 'new') {
+        window.location.href = '/register_user';
+      } else {
+        alert('Login failed');
+      }
+    }
+
+    function showDashboard() {
+      loginContainer.style.display = 'none';
+      dashboard.style.display = 'block';
+    }
+
+    googleBtn.onclick = handleGoogleLogin;
+    logoutBtn.onclick = async () => {
+      await signOut(auth);
+      localStorage.removeItem('primary_id');
+      location.reload();
+    };
+
+    window.addEventListener('load', async () => {
+      const stored = localStorage.getItem('primary_id');
+      if (stored) {
+        const res = await fetch(`/get_user?primary_id=${stored}`);
+        if (res.ok) {
+          const doc = await res.json();
+          if (doc.auth) { showDashboard(); return; }
+        }
+      }
+      loginContainer.style.display = 'flex';
+    });
+
+    document.getElementById('uploadBtn').onclick = async () => {
+      const fileInput = document.getElementById('receiptFile');
+      if (!fileInput.files.length) { alert('Select a file'); return; }
+      const primary = localStorage.getItem('primary_id');
+      if (!primary) { alert('Not logged in'); return; }
+      const form = new FormData();
+      form.append('file', fileInput.files[0]);
+      form.append('session_id', crypto.randomUUID());
+      form.append('identifier', primary);
+      form.append('source', 'WEB');
+      form.append('timestamp', new Date().toISOString());
+      const resp = await fetch('/upload', { method:'POST', body:form });
+      const data = await resp.json();
+      if (resp.ok) {
+        document.getElementById('uploadResult').textContent = 'Upload successful!';
+      } else {
+        document.getElementById('uploadResult').textContent = data.error || 'Upload failed';
+      }
+    };
+  </script>
+</body>
+</html>

--- a/flask_api/main_api.py
+++ b/flask_api/main_api.py
@@ -67,6 +67,20 @@ def register_user_page():
         firebase_config = json.load(f)
     return render_template('register.html', firebase_config=firebase_config)
 
+# Serve page for uploading receipts via the web dashboard
+@app.route('/upload_page', methods=['GET'])
+def upload_page():
+    with open(os.path.join(code_dir, 'firebaseConfig.json'), 'r') as f:
+        firebase_config = json.load(f)
+    return render_template('upload.html', firebase_config=firebase_config)
+
+# Serve simple chat interface
+@app.route('/chat_page', methods=['GET'])
+def chat_page():
+    with open(os.path.join(code_dir, 'firebaseConfig.json'), 'r') as f:
+        firebase_config = json.load(f)
+    return render_template('chat.html', firebase_config=firebase_config)
+
 # Route providing aggregated summary for a specific user
 @app.route('/summary', methods=['GET'])
 def summary():
@@ -326,6 +340,27 @@ def get_data():
         return jsonify({'error': 'No data found'}), 404
     logging.info(f"Returning summarised data for {len(df)} records")
     return jsonify(df.to_dict(orient='records'))
+
+# Simple chat endpoint using Gemini if available
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json() or {}
+    message = data.get('message', '')
+    if not message:
+        return jsonify({'error': 'No message provided'}), 400
+    reply = 'Hello! Ask me about your receipts.'
+    api_key = os.getenv('GEMINI_API_KEY')
+    if api_key:
+        try:
+            import google.generativeai as genai
+            genai.configure(api_key=api_key)
+            model = genai.GenerativeModel('gemini-pro')
+            resp = model.generate_content(message)
+            if resp.candidates:
+                reply = resp.candidates[0].content.parts[0].text.strip()
+        except Exception as e:
+            logging.error(f'Gemini API error: {e}')
+    return jsonify({'response': reply})
 
 if __name__ == '__main__':
     # This will only run when called directly (for development/testing)

--- a/flask_api/requirements.txt
+++ b/flask_api/requirements.txt
@@ -8,3 +8,4 @@ flask
 Pillow
 pandas
 numpy
+google-generativeai

--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-from .flask_api.gcp_adk_classification import ADKClient
+from flask_api.gcp_adk_classification import ADKClient
 import json
 
 prompt_dict = {


### PR DESCRIPTION
## Summary
- expand dashboard navigation links
- add receipt upload page for web users
- add chatbot page for simple questions
- serve new pages from Flask
- add Gemini-powered `/chat` endpoint
- include `google-generativeai` in API requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test.py` *(fails: connection refused to localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_e_687cd272cf6883259edff77bafec5a7d