### PR TITLE
Fix registration overwrite

### DIFF
--- a/flask_api/dashboard/already_registered.html
+++ b/flask_api/dashboard/already_registered.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Registration Error</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: #f4f7fa;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            background-color: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 6px 10px rgba(0,0,0,0.15);
+            padding: 40px;
+            text-align: center;
+            width: 400px;
+        }
+        h2 { color: #d9534f; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Registration Error</h2>
+        <p>You are already Registered with another Email ID, if this is a Mistake or your Unable to Register email jonathanchacko1805@gmail.com to Get your Account Fixed.</p>
+    </div>
+</body>
+</html>

--- a/flask_api/dashboard/register.html
+++ b/flask_api/dashboard/register.html
@@ -69,17 +69,26 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ source: 'WEB', identifier: primary, primary_id: primary })
                 });
-                if (!resp.ok) { throw new Error('Registration failed'); }
                 const data = await resp.json();
+                if (resp.status === 409 && data.status === 'already_registered') {
+                    window.location.href = '/already_registered';
+                    return;
+                }
+                if (!resp.ok) { throw new Error('Registration failed'); }
                 const sessionId = data.session_id;
                 const provider = new GoogleAuthProvider();
                 const result = await signInWithPopup(auth, provider);
                 const idToken = await result.user.getIdToken();
-                await fetch(`/authenticate/FALSE/${sessionId}`, {
+                const authResp = await fetch(`/authenticate/FALSE/${sessionId}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ idToken })
                 });
+                const authData = await authResp.json();
+                if (authResp.status === 409 && authData.status === 'already_registered') {
+                    window.location.href = '/already_registered';
+                    return;
+                }
                 localStorage.setItem('primary_id', primary);
                 window.location.href = '/';
             } catch (err) {

--- a/flask_api/main_api.py
+++ b/flask_api/main_api.py
@@ -69,6 +69,11 @@ def register_user_page():
         firebase_config = json.load(f)
     return render_template('register.html', firebase_config=firebase_config)
 
+# Inform user when attempting to register with an existing account
+@app.route('/already_registered', methods=['GET'])
+def already_registered_page():
+    return render_template('already_registered.html')
+
 # Serve page for uploading receipts via the web dashboard
 @app.route('/upload_page', methods=['GET'])
 def upload_page():
@@ -153,6 +158,11 @@ def register():
     logging.info(f"Register request: source={source}, identifier={identifier}, primary_id={primary_id}")
     if not source or not identifier:
         return jsonify({'error': 'Missing source or identifier'}), 400
+    existing_doc = get_user_document(primary_id)
+    if existing_doc and 'auth' in existing_doc:
+        logging.warning(f"Registration attempt for existing user {primary_id}")
+        return jsonify({'status': 'already_registered'}), 409
+
     session_id = create_user(primary_id, source, identifier)
     logging.info(f"User created/updated: {primary_id} -> {source}:{identifier}")
     return jsonify({'status': 'registered', 'primary_id': primary_id, 'session_id': session_id}), 200


### PR DESCRIPTION
## Summary
- prevent overriding auth identifier when registering
- notify registration page if account exists
- add page informing the user they are already registered

## Testing
- `python -m py_compile flask_api/main_api.py flask_api/firebase_store.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d201a2f08325b9293b9e890dda8d